### PR TITLE
add required extension: ext-gmp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: php
 
 php:
+  - 5.6
   - 7.0
   - 7.1
   - hhvm
+
+sudo: false
 
 # This triggers builds to run on the new TravisCI infrastructure.
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
@@ -13,6 +16,15 @@ sudo: false
 cache:
   directories:
     - $HOME/.composer/cache
+
+matrix:
+  include:
+    - php: 5.6
+      env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
+  allow_failures:
+    - php:
+        - 5.6
+        - hhvm
 
 before_script:
   - travis_retry composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
-  - hhvm
 
 sudo: false
 
@@ -16,15 +14,6 @@ sudo: false
 cache:
   directories:
     - $HOME/.composer/cache
-
-matrix:
-  include:
-    - php: 5.6
-      env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
-  allow_failures:
-    - php:
-        - 5.6
-        - hhvm
 
 before_script:
   - travis_retry composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - hhvm
@@ -14,11 +13,6 @@ sudo: false
 cache:
   directories:
     - $HOME/.composer/cache
-
-matrix:
-  include:
-    - php: 5.6
-      env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
 
 before_script:
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         }
     ],
     "require": {
-        "php": "~7.0"
+        "php": "~7.0",
+        "ext-gmp": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.6",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "~7.0",
+        "php": "^5.6 || ~7.0",
         "ext-gmp": "*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ~7.0",
+        "php": "~7.0",
         "ext-gmp": "*"
     },
     "require-dev": {


### PR DESCRIPTION
# Change log

- Add required extension: ```ext-gmp```.
- When installing this package, the composer will check the extension whether is installed.
- Modify the PHP version in ```composer.json``` to complete the travis-ci service successfully.